### PR TITLE
Dev sourmash rmd

### DIFF
--- a/rmarkdown_reports/templates/sourmash.Rmd
+++ b/rmarkdown_reports/templates/sourmash.Rmd
@@ -54,9 +54,9 @@ if (METAGENOMIC_DATA_EXIST) {
 ```
 
 `r if(CLASSIFICATION_DATA_EXIST) {
-	ifelse(SOURMASH_STATUS == "found", sprintf("Status of the classification is: <span style="color:green">**%s**</span>.\n", SOURMASH_STATUS),
-		ifelse(SOURMASH_STATUS == "disagree", sprintf("Status of the classification is: <span style="color:orange">**%s**</span>.\n", SOURMASH_STATUS),
-			sprintf("Status of the classification is: <span style="color:red">**%s**</span>.\n", SOURMASH_STATUS)))
+	ifelse(SOURMASH_STATUS == "found", sprintf("Status of the classification is: <span style='color:green'>**%s**</span>.\n", SOURMASH_STATUS),
+		ifelse(SOURMASH_STATUS == "disagree", sprintf("Status of the classification is: <span style='color:orange'>**%s**</span>.\n", SOURMASH_STATUS),
+			sprintf("Status of the classification is: <span style='color:red'>**%s**</span>.\n", SOURMASH_STATUS)))
 } else {
 	sprintf("Classification of the sample **failed**.")
 }`
@@ -93,9 +93,9 @@ Strain|%s",
 
 `r if (METAGENOMIC_DATA_EXIST) {
 	if (METAGENOMIC_DATA_EXIST & METAGENOMIC_DATA_NOT_EMPTY) {
-		ifelse(F_UNIQUE_TO_QUERY_PERCENTAGE < 10, sprintf("<span style="color:red">Warning, less than 10 percent could be taxonomically assigned to the analysed genome:\nThe organism might not be a bacteria/archea, is completely unknown without any close relatives, or the sample contains lots of contamination.</span>"),
-			ifelse(F_UNIQUE_TO_QUERY_PERCENTAGE < 50, sprintf("<span style="color:red">Warning, less than 50 percent could be taxonomically assigned to analysed genome:\nThe organism might not be a bacteria/archea, is unknown, or the sample contains lots of contamination.</span>"),
-				ifelse(F_UNIQUE_TO_QUERY_PERCENTAGE < 80, sprintf("<span style="color:red">Warning, less than 80 percent could be taxonomically assigned to the analysed genome:\nThe organism might be an unknown bacteria/archea species or the sample contains to much contamination.</span>"),
+		ifelse(F_UNIQUE_TO_QUERY_PERCENTAGE < 10, sprintf("<span style='color:red'>Warning, less than 10 percent could be taxonomically assigned to the analysed genome:\nThe organism might not be a bacteria/archea, is completely unknown without any close relatives, or the sample contains lots of contamination.</span>"),
+			ifelse(F_UNIQUE_TO_QUERY_PERCENTAGE < 50, sprintf("<span style='color:red'>Warning, less than 50 percent could be taxonomically assigned to analysed genome:\nThe organism might not be a bacteria/archea, is unknown, or the sample contains lots of contamination.</span>"),
+				ifelse(F_UNIQUE_TO_QUERY_PERCENTAGE < 80, sprintf("<span style='color:red'>Warning, less than 80 percent could be taxonomically assigned to the analysed genome:\nThe organism might be an unknown bacteria/archea species or the sample contains to much contamination.</span>"),
 					sprintf("The percentage of unique bases of %s in the analysed sequence amounts to %s percent.", METAGENOMIC_ORGANISM_WITH_HIGHEST_PROBABILITY, F_UNIQUE_TO_QUERY_PERCENTAGE))))
 	}
 }`


### PR DESCRIPTION
Closes Issue #15 
Added HTML color-coding to status print based on status in the taxonomy-file: "found": green, "disagree": orange & "nomatch": red.
Added also HTML color-coding to warning-prints if "f_unique_to_query" is below the thresholds.

Works for the "test_fasta" profile & if changed manually to the aforementioned options. But not 100 % sure if sourmash still uses this three options for "Status" in the taxonomy-file or something else.